### PR TITLE
Fixed timeline when viewed on lower resolutions, e.g. mobile phones

### DIFF
--- a/kasse/templatetags/kasse_extras.py
+++ b/kasse/templatetags/kasse_extras.py
@@ -72,3 +72,11 @@ def strip_space_after_tag(o, autoescape=True):
     else:
         s = '%s' % (o,)
     return mark_safe(s.replace("> ", ">", 1))
+
+
+@register.filter
+def pct(value, arg):
+    try:
+        return '{0:.5g}'.format(value / arg * 100)
+    except (ValueError, ZeroDivisionError):
+        return None

--- a/stopwatch/templates/stopwatch/timetrialtimeline.html
+++ b/stopwatch/templates/stopwatch/timetrialtimeline.html
@@ -7,11 +7,14 @@
 .timelinerow {
 	display: flex;
 }
-.timelinerow > *:nth-child(even) {
+.timelinerow div > div:nth-child(odd) {
 	background-color: #ccc;
 }
-.timelinerow > *:last-child {
+.timelinerow div > div:last-child {
 	border-right: 1px solid black;
+}
+.timelinerow > div {
+	display: flex;
 }
 </style>
 {% endblock %}
@@ -24,12 +27,14 @@
 {{ object.profile }}
 </a>
 </div>
+<div style="width: 500px">
 {% for leg in object.leg_set.all %}
-<div style="width: {% widthratio leg.duration duration 500 %}px; text-align: right"
+<div style="width: {{ leg.duration|pct:duration }}%; text-align: right"
 title="Øl {{ leg.order }} færdig efter {{ leg.duration_prefix_sum }} s">
 {{ leg.order }}
 </div>
 {% endfor %}
+</div>
 </div>
 {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Fix for viewing the timeline on lower resolution devices. There are still some alignment issues when the screen gets too short to contain both the timeline and a word-wrapped name, but at that point, you're better off buying a new device anyway.