### PR TITLE
Fixed HTTP 500 error on timetrial/json/live

### DIFF
--- a/stopwatch/views.py
+++ b/stopwatch/views.py
@@ -464,7 +464,7 @@ class IndentJSONEncoder(DjangoJSONEncoder):
 
 
 class Json(View):
-    def get(self, request):
+    def get(self, request, *args, **kwargs):
         data = []
         qs = TimeTrial.objects.all()
         if self.kwargs.get('live'):


### PR DESCRIPTION
Trying to access https://enkasseienfestforening.dk/timetrial/json/live/ returns a 500 Internal Server Error. This should fix that.