### PR TITLE
Automatically update season on 1st of September each year

### DIFF
--- a/kasse/views.py
+++ b/kasse/views.py
@@ -93,7 +93,9 @@ class Home(TemplateView):
 
     @staticmethod
     def get_season_start():
-        return datetime.date(2022, 9, 1)
+        now = datetime.now()
+        season_year_start = now.year if now.month >= 9 else now.year-1
+        return datetime.date(season_year_start, 9, 1)
 
     def get_current_best(self, **kwargs):
         season_start = Home.get_season_start()

--- a/kasse/views.py
+++ b/kasse/views.py
@@ -93,7 +93,7 @@ class Home(TemplateView):
 
     @staticmethod
     def get_season_start():
-        now = datetime.now()
+        now = datetime.date.today()
         season_year_start = now.year if now.month >= 9 else now.year-1
         return datetime.date(season_year_start, 9, 1)
 


### PR DESCRIPTION
              Thanks! The repo is still in use but it's not seeing any active development. It's stupid that the season start is controlled in code - it makes it a bit much work to update, so I'd neglected to do so ever since lockdown started.

_Originally posted by @Mortal in https://github.com/TK-IT/kasse/issues/86#issuecomment-1434320570_
            
            
Let's be lazy then! This PR should automatically reference the correct season based on what part of the year we are in (September-December or not)